### PR TITLE
Revert "Fix: graceful fallback when SIFT is unavailable (missing opencv-contrib-python)"

### DIFF
--- a/bdnex/lib/cover.py
+++ b/bdnex/lib/cover.py
@@ -47,14 +47,7 @@ def front_cover_similarity(original, image_to_compare):
     image_to_compare_cv = imutils.resize(image_to_compare_cv, height=600)
 
     # Check for similarities between the 2 images
-    try:
-        sift = cv2.xfeatures2d.SIFT_create()
-    except AttributeError:
-        logger.error(
-            "SIFT is not available. Install opencv-contrib-python: "
-            "pip install opencv-contrib-python"
-        )
-        return 0
+    sift = cv2.xfeatures2d.SIFT_create()
     kp_1, desc_1 = sift.detectAndCompute(original_cv, None)
     kp_2, desc_2 = sift.detectAndCompute(image_to_compare_cv, None)
 

--- a/test/test_cover.py
+++ b/test/test_cover.py
@@ -1,8 +1,5 @@
 import os
 import unittest
-from unittest.mock import patch
-
-import cv2
 
 from bdnex.lib.cover import front_cover_similarity
 
@@ -22,13 +19,6 @@ class TestCover(unittest.TestCase):
         # check bad cover similarity
         match_res = front_cover_similarity(ARCHIVE_COVER, BDGEST_OTHER_COVER)
         self.assertEqual(True, match_res < 5)
-
-
-    def test_front_cover_similarity_sift_unavailable(self):
-        # When SIFT is not available (cv2.xfeatures2d missing), should return 0 gracefully
-        with patch.object(cv2, 'xfeatures2d', new=object()):
-            match_res = front_cover_similarity(ARCHIVE_COVER, BDGEST_COVER)
-            self.assertEqual(0, match_res)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reverts kcgthb/bdnex#17